### PR TITLE
Fix code sample using Viewport height

### DIFF
--- a/docs/pages/cover.md
+++ b/docs/pages/cover.md
@@ -86,7 +86,7 @@ To add responsive behavior to your cover image, you need to create an invisible 
 Adding the `.uk-height-viewport` class from the [Utility component](utility.md) will stretch the height of the parent element to fill the whole viewport.
 
 ```html
-<div class="uk-cover-container" uk-height-viewport>
+<div class="uk-cover-container uk-height-viewport">
     <img src="" alt="" uk-cover>
 </div>
 ```


### PR DESCRIPTION
Use this code sample will not work
```html
<div class="uk-cover-container" uk-height-viewport>
    <img src="" alt="" uk-cover>
</div>
```

Instead, use this
```html
<div class="uk-cover-container uk-height-viewport">
    <img src="" alt="" uk-cover>
</div>
```