### PR TITLE
Use correct modal id in group example

### DIFF
--- a/docs/pages/modal.md
+++ b/docs/pages/modal.md
@@ -348,7 +348,7 @@ You can group multiple modals by linking from one to the other and back. Use thi
     </div>
 </div>
 
-<div id="modal-group-1" uk-modal>
+<div id="modal-group-2" uk-modal>
     <div class="uk-modal-dialog">
         <a href="#modal-group-1" uk-toggle>Previous</a>
     </div>


### PR DESCRIPTION
The docs for modal group have two modals with the same ID. One of them should have the ID #modal-group-2.