### PR TITLE
How to access the dynamically loaded svg

### DIFF
--- a/docs/pages/icon.md
+++ b/docs/pages/icon.md
@@ -382,3 +382,10 @@ Learn more about [JavaScript components](javascript.md#programmatic-use).
 ```js
 UIkit.icon(element, options);
 ```
+### Properties
+
+Native svg icons are loaded into the UIkit icon container via a javascript promise, which is accessible though the `svg` property of the component. If you need to access the loaded svg, you can do so once the promise has been fulfulled, using `.then`. For example, to change the fill colour of parts of a dynamically generated icon
+
+```example
+UIkit.icon(element).svg.then(function() {$('svg path',element).css('fill', 'red')})
+```


### PR DESCRIPTION
As discussed with @florianletsch on gitter. Note that for static icons, colour change can be done more easily by adding a css rule in the main stylesheet, but this can't be done if the icon is dynamic and the colour is altered programmatically. There may be other uses for adjusting the svg DOM too.