### PR TITLE
RTL page - Broken link [404] for "setup UIkit from Github source"

### DIFF
--- a/docs/pages/rtl.md
+++ b/docs/pages/rtl.md
@@ -30,7 +30,7 @@ Take a look at the available components and just create markup as usual. There i
 
 ## Compile from source
 
-If you [setup UIkit from Github source](setup.md#compile-from-github-source), you can also compile the RTL version of UIkit yourself. This will include any [custom UIkit theme](less.md) you have created in the `custom/` directory.
+If you [setup UIkit from Github source](installation.md#compile-from-github-source), you can also compile the RTL version of UIkit yourself. This will include any [custom UIkit theme](less.md) you have created in the `custom/` directory.
 
 ```sh
 npm install


### PR DESCRIPTION
"setup UIkit from Github source" is broken (leads to this HREF):
https://getuikit.com/docs/setup#compile-from-github-source
(should be installation - not setup)
https://getuikit.com/docs/installation#compile-from-github-source