### PR TITLE
Add meta viewport in Basic Html Markup

### DIFF
--- a/docs/pages/introduction.md
+++ b/docs/pages/introduction.md
@@ -27,7 +27,9 @@ Add the compiled and minified CSS and JavaScript to the header of your HTML5 doc
 <!DOCTYPE html>
 <html>
     <head>
-        <title></title>
+        <!-- required meta tag -->
+        <meta name="viewport" content="width=device-width, initial-scale=1">
+        <title>Title</title>
         <link rel="stylesheet" href="css/uikit.min.css" />
         <script src="js/jquery.js"></script>
         <script src="js/uikit.min.js"></script>


### PR DESCRIPTION
It´s not UIkit subject, but since it´s essential for the responsive design to work, add media viewport to basic html structure.
This prevents a bad experience for new user making first steps in responsive design, i see it quite often in Gitter.