### PR TITLE
Use https source links

### DIFF
--- a/docs/pages/utility.md
+++ b/docs/pages/utility.md
@@ -651,15 +651,15 @@ To automatically mute or play videos, add the `uk-video` attribute. The video wi
 
         <button class="uk-button uk-button-default uk-margin" type="button" uk-toggle="target: +">Toggle HTML5 Video</button>
         <video controls playsinline uk-video="automute: true">
-            <source src="http://www.quirksmode.org/html5/videos/big_buck_bunny.mp4" type="video/mp4">
-            <source src="http://www.quirksmode.org/html5/videos/big_buck_bunny.ogv" type="video/ogg">
+            <source src="//www.quirksmode.org/html5/videos/big_buck_bunny.mp4" type="video/mp4">
+            <source src="//www.quirksmode.org/html5/videos/big_buck_bunny.ogv" type="video/ogg">
         </video>
 
     </div>
     <div>
 
         <button class="uk-button uk-button-default uk-margin-bottom" type="button" uk-toggle="target: +">Toggle Youtube Video</button>
-        <iframe src="http://www.youtube.com/embed/YE7VzlLtp-4?autoplay=0&amp;showinfo=0&amp;rel=0&amp;modestbranding=1&amp;playsinline=1" width="560" height="315" frameborder="0" allowfullscreen uk-responsive uk-video="automute: true"></iframe>
+        <iframe src="//www.youtube.com/embed/YE7VzlLtp-4?autoplay=0&amp;showinfo=0&amp;rel=0&amp;modestbranding=1&amp;playsinline=1" width="560" height="315" frameborder="0" allowfullscreen uk-responsive uk-video="automute: true"></iframe>
 
     </div>
 </div>


### PR DESCRIPTION
Mixed Content: The page at 'https://getuikit.com/docs/utility' was loaded over HTTPS, but requested an insecure resource 'http://www.youtube.com/embed/YE7VzlLtp-4?autoplay=0&showinfo=0&rel=0&modestbranding=1&playsinline=1'. This request has been blocked; the content must be served over HTTPS.