### PR TITLE
add missing code examples lang

### DIFF
--- a/docs/pages/breadcrumb.md
+++ b/docs/pages/breadcrumb.md
@@ -8,7 +8,7 @@ The Breadcrumb component consists of links, which are aligned side by side and s
 
 To add list items without a link, use a `<span>` element instead of an `<a>`. Alternatively, disable an `<a>` element by adding the `.uk-disabled` class to the `<li>` element and remove the `href` attribute from the anchor to make it inaccessible through keyboard navigation.
 
-```
+```html
 <ul class="uk-breadcrumb">
     <li><a href=""></a></li>
     <li><a href=""></a></li>

--- a/docs/pages/less.md
+++ b/docs/pages/less.md
@@ -191,7 +191,7 @@ The entry point for the Less compiler, `/custom/my-theme.less`:
 
 Your theme folder has one file which imports all single component customizations, `custom/my-theme/_import.less`:
 
-```
+```less
 @import "accordion.less";
 @import "alert.less";
 // ...


### PR DESCRIPTION
Not having them leads to potentials bugs with markdowns compiling.