### PR TITLE
Changed class name in "Navigation outside" example

### DIFF
--- a/docs/pages/slider.md
+++ b/docs/pages/slider.md
@@ -429,7 +429,7 @@ To place a navigation outside of a slider, add the `.uk-position-center-left-out
         </div>
 
         <a class="uk-position-center-left-out" href="#" uk-slider-item="previous">...</a>
-        <a class="uk-position-center-left-out" href="#" uk-slider-item="next">...</a>
+        <a class="uk-position-center-right-out" href="#" uk-slider-item="next">...</a>
 
     </div>
 


### PR DESCRIPTION
The class name of the "next" arrow of the Navigation outside should be "-right-" instead of "-left-".