### PR TITLE
semantic change

### DIFF
--- a/docs/pages/introduction.md
+++ b/docs/pages/introduction.md
@@ -21,7 +21,7 @@ The Zip file contains the compiled CSS and JavaScript files, which is everything
 
 ## HTML markup
 
-Add the compiled and minified CSS and JavaScript to the header of your HTML5 document. Also include the UIkit icon library. For your basic setup, that's it.
+Add the compiled and minified CSS and JavaScript to the head of your HTML5 document. Also include the UIkit icon library. For your basic setup, that's it.
 
 ```html
 <!DOCTYPE html>


### PR DESCRIPTION
Text referred to adding the UIKit source links and script tags to the "header", when it was really referring to the "head" section of the HTML doc.