### PR TITLE
Added attribute prefix "data-"

### DIFF
--- a/docs/pages/lightbox.md
+++ b/docs/pages/lightbox.md
@@ -54,17 +54,17 @@ By default, the Lightbox gallery uses a slide animation. You can set the `animat
 <div class="uk-h3">Slide</div>
 <div class="uk-child-width-1-3@m" uk-grid uk-lightbox="animation: slide">
     <div>
-        <a class="uk-inline" href="../docs/images/photo.jpg" caption="Caption 1">
+        <a class="uk-inline" href="../docs/images/photo.jpg" data-caption="Caption 1">
             <img src="../docs/images/photo.jpg" alt="">
         </a>
     </div>
     <div>
-        <a class="uk-inline" href="../docs/images/dark.jpg" caption="Caption 2">
+        <a class="uk-inline" href="../docs/images/dark.jpg" data-caption="Caption 2">
             <img src="../docs/images/dark.jpg" alt="">
         </a>
     </div>
     <div>
-        <a class="uk-inline" href="../docs/images/light.jpg" caption="Caption 3">
+        <a class="uk-inline" href="../docs/images/light.jpg" data-caption="Caption 3">
             <img src="../docs/images/light.jpg" alt="">
         </a>
     </div>
@@ -73,17 +73,17 @@ By default, the Lightbox gallery uses a slide animation. You can set the `animat
 <div class="uk-h3">Fade</div>
 <div class="uk-child-width-1-3@m" uk-grid uk-lightbox="animation: fade">
     <div>
-        <a class="uk-inline" href="../docs/images/photo.jpg" caption="Caption 1">
+        <a class="uk-inline" href="../docs/images/photo.jpg" data-caption="Caption 1">
             <img src="../docs/images/photo.jpg" alt="">
         </a>
     </div>
     <div>
-        <a class="uk-inline" href="../docs/images/dark.jpg" caption="Caption 2">
+        <a class="uk-inline" href="../docs/images/dark.jpg" data-caption="Caption 2">
             <img src="../docs/images/dark.jpg" alt="">
         </a>
     </div>
     <div>
-        <a class="uk-inline" href="../docs/images/light.jpg" caption="Caption 3">
+        <a class="uk-inline" href="../docs/images/light.jpg" data-caption="Caption 3">
             <img src="../docs/images/light.jpg" alt="">
         </a>
     </div>
@@ -92,17 +92,17 @@ By default, the Lightbox gallery uses a slide animation. You can set the `animat
 <div class="uk-h3">Scale</div>
 <div class="uk-child-width-1-3@m" uk-grid uk-lightbox="animation: scale">
     <div>
-        <a class="uk-inline" href="../docs/images/photo.jpg" caption="Caption 1">
+        <a class="uk-inline" href="../docs/images/photo.jpg" data-caption="Caption 1">
             <img src="../docs/images/photo.jpg" alt="">
         </a>
     </div>
     <div>
-        <a class="uk-inline" href="../docs/images/dark.jpg" caption="Caption 2">
+        <a class="uk-inline" href="../docs/images/dark.jpg" data-caption="Caption 2">
             <img src="../docs/images/dark.jpg" alt="">
         </a>
     </div>
     <div>
-        <a class="uk-inline" href="../docs/images/light.jpg" caption="Caption 3">
+        <a class="uk-inline" href="../docs/images/light.jpg" data-caption="Caption 3">
             <img src="../docs/images/light.jpg" alt="">
         </a>
     </div>
@@ -126,11 +126,11 @@ A lightbox is not restricted to images. Other media, like videos, can be display
 
 ```example
 <div uk-lightbox>
-    <a class="uk-button uk-button-default" href="../docs/images/photo.jpg" caption="Image">Image</a>
-    <a class="uk-button uk-button-default" href="//www.quirksmode.org/html5/videos/big_buck_bunny.mp4" caption="Video">Video</a>
-    <a class="uk-button uk-button-default" href="//www.youtube.com/watch?v=YE7VzlLtp-4" caption="YouTube">YouTube</a>
-    <a class="uk-button uk-button-default" href="//vimeo.com/1084537" caption="Vimeo">Vimeo</a>
-    <a class="uk-button uk-button-default" href="//www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d4740.819266853735!2d9.99008871708242!3d53.550454675412404!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x0%3A0x3f9d24afe84a0263!2sRathaus!5e0!3m2!1sde!2sde!4v1499675200938" caption="Google Maps" type="iframe">Google Maps</a>
+    <a class="uk-button uk-button-default" href="../docs/images/photo.jpg" data-caption="Image">Image</a>
+    <a class="uk-button uk-button-default" href="//www.quirksmode.org/html5/videos/big_buck_bunny.mp4" data-caption="Video">Video</a>
+    <a class="uk-button uk-button-default" href="//www.youtube.com/watch?v=YE7VzlLtp-4" data-caption="YouTube">YouTube</a>
+    <a class="uk-button uk-button-default" href="//vimeo.com/1084537" data-caption="Vimeo">Vimeo</a>
+    <a class="uk-button uk-button-default" href="//www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d4740.819266853735!2d9.99008871708242!3d53.550454675412404!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x0%3A0x3f9d24afe84a0263!2sRathaus!5e0!3m2!1sde!2sde!4v1499675200938" data-caption="Google Maps" data-type="iframe">Google Maps</a>
 </div>
 ```
 


### PR DESCRIPTION
In the text the attributes are named "data-caption" and "data-type". In the example markup the "data-" was sometimes omitted. Both seem to work fine but the difference might be irritating.