### PR TITLE
Add documentation for ratio property on uk-spinner

### DIFF
--- a/docs/pages/spinner.md
+++ b/docs/pages/spinner.md
@@ -13,3 +13,16 @@ To create a spinner, add the `uk-spinner` attribute to a block element.
 ```example
 <div uk-spinner></div>
 ```
+
+## Ratio
+
+Add the `ratio: 3` parameter to the `uk-spinner` attribute to triple its size – or any other number, depending on how big you want the spinner to be.
+
+```html
+<div uk-spinner="ratio: 3"></div>
+```
+
+```example
+<span class="uk-margin-small-right" uk-spinner="ratio: 3"></span>
+<span uk-spinner="ratio: 4.5"></span>
+```


### PR DESCRIPTION
The `ratio` property on the `uk-spinner` component is used in the example sites, but is not documented anywhere. I added an example based on the `uk-icon` documentation.