### PR TITLE
Remove data-type in Upload docs

### DIFF
--- a/docs/pages/upload.md
+++ b/docs/pages/upload.md
@@ -189,7 +189,6 @@ Any of these options can be applied to the component attribute. Separate multipl
 | `allow`            | String   | `false`                 | File name filter. (eg. *.png)                               |
 | `mime`             | String   | `false`                 | File MIME type filter. (eg. image/*)                        |
 | `concurrent`       | Number   | `1`                     | Number of files that will be uploaded simultaneously.       |
-| `data-type`        | String   | `'''                    | The expected response data type: xml, json, script, or html |
 | `msg-invalid-mime` | String   | `Invalid File Type: %s` | Invalid MIME type message.                                  |
 | `msg-invalid-name` | String   | `Invalid File Name: %s` | Invalid name message.                                       |
 | `cls-dragover`     | String   | `uk-dragover`           | File name filter.                                           |


### PR DESCRIPTION
This option doesn't exist in the code, as confirmed by @janschoenherr here: https://github.com/uikit/uikit/issues/3275