### PR TITLE
By default, width is auto, cells are not stacked.

### DIFF
--- a/docs/pages/grid.md
+++ b/docs/pages/grid.md
@@ -8,7 +8,7 @@ The Grid system of UIkit allows you to arrange block elements in columns. It wor
 
 ## Usage
 
-To create the grid container, add the `uk-grid` attribute to a `<div>` element. Add child `<div>` elements to create the cells. By default, all grid cells are stacked. To place them side by side, add one of the classes from the [Width component](width.md). Using `.uk-child-width-expand` will automatically apply equal width to items, regardless of how many there are.
+To create the grid container, add the `uk-grid` attribute to a `<div>` element. Add child `<div>` elements to create the cells. By default, all grid cells have a `width` of `auto`, the width of each cell then, will be determined by the content inside of it. To give the cells determined widths, add one of the classes from the [Width component](width.md). Using `.uk-child-width-expand` will automatically apply equal width to items, regardless of how many there are.
 
 **Note** There's no need to add a `.uk-grid` class as it will be added via JavaScript. However, if UIkit's JavaScript is [deferred](https://developer.mozilla.org/docs/Web/HTML/Element/script#attr-defer), the class should be added to prevent stacking while loading.
 


### PR DESCRIPTION
Cells are not stacked by default, they may be side by side from the start if the content inside of the cells are narrow enough they they don't wrap on to the next line.