### PR TITLE
Update modal.md

### DIFF
--- a/docs/pages/modal.md
+++ b/docs/pages/modal.md
@@ -399,13 +399,13 @@ Any of these options can be applied to the component attribute. Separate multipl
 
 | Option      | Value   | Default | Description                                                                                        |
 |:------------|:--------|:--------|:---------------------------------------------------------------------------------------------------|
-| `esc-close` | Boolean | `true`  | Close the modal when the _Esc_ key is pressed.                                                     |
-| `bg-close`  | Boolean | `true`  | Close the modal when the background is clicked.                                                    |
+| `escClose` | Boolean | `true`  | Close the modal when the _Esc_ key is pressed.                                                     |
+| `bgClose`  | Boolean | `true`  | Close the modal when the background is clicked.                                                    |
 | `stack`     | Boolean | `false` | Stack modals, when more than one is open. By default, the previous modal will be hidden.           |
 | `container` | String  | `true`  | Define a target container via a selector to specify where the modal should be appended in the DOM. Setting it to `false` will prevent this behavior. |
-| `cls-page`  | String  | `'uk-modal-page'`   | Class to add to `<body>` when modal is active                |
-| `cls-panel` | String  | `'uk-modal-dialog'` | Class of the element to be considered the panel of the modal |
-| `sel-close` | String  | `'.uk-modal-close,` `.uk-modal-close-default,` `.uk-modal-close-outside,` `.uk-modal-close-full'` | CSS selector for all elements that should trigger the closing of the modal |
+| `clsPage`  | String  | `'uk-modal-page'`   | Class to add to `<body>` when modal is active                |
+| `clsPanel` | String  | `'uk-modal-dialog'` | Class of the element to be considered the panel of the modal |
+| `selClose` | String  | `'.uk-modal-close,` `.uk-modal-close-default,` `.uk-modal-close-outside,` `.uk-modal-close-full'` | CSS selector for all elements that should trigger the closing of the modal |
 
 ***
 


### PR DESCRIPTION
Fixing a few errors on the component options documentation values. Hyphen (-) values don't work. After changing the values to their Camel Case alternative, avoids conflicts and prevent typing errors.