### PR TITLE
Update javascript.md

### DIFF
--- a/docs/pages/javascript.md
+++ b/docs/pages/javascript.md
@@ -117,7 +117,7 @@ UIkit.mixin({
 
 ## Programmatic use
 
-Programmatically, components may be initialized with the `element, options` arguments format in JavaScript. The `element` argument may be any `Node`, `selector` or `jQuery object`. You'll receive the initialized component as return value. `Functional Components` (e.g. `Notification`) should omit the `element` parameter.
+Programmatically, components may be initialized with the `element, options` arguments format in JavaScript. The `element` argument may be any `Node` or `selector`. You'll receive the initialized component as return value. `Functional Components` (e.g. `Notification`) should omit the `element` parameter.
 
 ```js
 // Passing a selector and an options object.


### PR DESCRIPTION
Correct me if I'm wrong but after I updated from 3.1.9 to 3.2.1 this is clearly not supported anymore. I tried initializing modals, drops and filters. I observe that only a selector or a DOM node is accepted to initialize the component. Additionally I also observed the same behavior with passing a component to UIkit.util.on(). It can be only a selector or a node. It's a pity though because it would be really handy that one could as well pass jQuery object or even a component ref itself.