### PR TITLE
Fix typo in text.md

### DIFF
--- a/docs/pages/text.md
+++ b/docs/pages/text.md
@@ -61,7 +61,7 @@ The following classes will transform text into uppercased, capitalized or lowerc
 
 ## Text decoration
 
-Add the `.uk-text-decoration-none` class to remove any text decoration form a <a class="uk-text-decoration-none" href>link</a>.
+Add the `.uk-text-decoration-none` class to remove any text decoration from a <a class="uk-text-decoration-none" href>link</a>.
 
 ***
 


### PR DESCRIPTION
Replace `form a link` with `from a link`