### PR TITLE
List component page - remove outdated reference to fixed bug

### DIFF
--- a/docs/pages/list.md
+++ b/docs/pages/list.md
@@ -150,8 +150,6 @@ Add one of the following classes to set the marker color.
 </div>
 ```
 
-**Note** The color modifiers don't work in Chrome and Edge because the `::marker` pseudo-element is not supported yet. Vote this [Chromium issue](https://bugs.chromium.org/p/chromium/issues/detail?id=457718) up, to give it more attention.
-
 ***
 
 ## Image bullet modifier


### PR DESCRIPTION
This note:

> The color modifiers don't work in Chrome and Edge because the `::marker` pseudo-element is not supported yet. Vote this [Chromium issue](https://bugs.chromium.org/p/chromium/issues/detail?id=457718) up, to give it more attention.

is no longer accurate for a vast majority of users, as the linked bug was marked as fixed and applied in a 2020 release. 

According to [Can I Use](https://caniuse.com/?search=%3A%3Amarker) only 1.25% of total global users are using versions of Chrome that don't support ::marker. For an amount that low I think it's worth removing the disclaimer - seeing it there might nudge people towards coming up with their own workaround, which is not ideal when the feature is actually working fine for 99% of people. 